### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1
+PRIVATE_KEY=abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1


### PR DESCRIPTION
the 0x in the .env.example is confusing for a private key input. Should remove this in favor of the dummy string.